### PR TITLE
Enhance project_id/project_name variable assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | folder\_id | The existing folder to use for the project | `string` | n/a | yes |
 | labels | Map of labels for project. | `map(string)` | <pre>{<br>  "environment": "automation",<br>  "managed_by": "terraform"<br>}</pre> | no |
 | org\_id | Organization id. | `string` | `"brown.edu"` | no |
+| project\_id | Make project\_id a user-settable parameter | `string` | `""` | no |
 | project\_name | The human readable name for the project factory | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,14 @@
+locals {
+  project_id = var.project_id == "" ? lower(replace(substr(var.project_name, 0, 24), " ", "-")) : var.project_id
+}
+
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "= 8.0.1"
 
   name                       = var.project_name
   random_project_id          = true
+  project_id                 = local.project_id
   org_id                     = var.org_id
   folder_id                  = var.folder_id
   billing_account            = var.billing_account

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,10 @@
-locals {
-  project_id = var.project_id == "" ? lower(replace(substr(var.project_name, 0, 24), " ", "-")) : var.project_id
-}
-
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "= 8.0.1"
 
   name                       = var.project_name
   random_project_id          = true
-  project_id                 = local.project_id
+  project_id                 = var.project_id == null ? lower(replace(substr(var.project_name, 0, 24), " ", "-")) : var.project_id
   org_id                     = var.org_id
   folder_id                  = var.folder_id
   billing_account            = var.billing_account

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "activate_apis" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ----------------------------------------------------------------------------
+variable "project_id" {
+  description = "Make project_id a user-settable parameter"
+  type        = string
+  default     = ""
+}
+
 variable "org_id" {
   description = "Organization id."
   type        = string


### PR DESCRIPTION
Add code to handle conventions in CIS Services folder where convention is project_name != project_id. Also ensures project_id meets API requirements of < 30 characters, no spaces, lower case.