### PR TITLE
Add support for terraform 0.13 from google-project-factory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "= 8.0.1"
+  version = "= 9.0.0"
 
   name                       = var.project_name
   random_project_id          = true


### PR DESCRIPTION
I need support for terraform 0.13 in another project I'm working on from a vendor and I need to bump the upstream module reference to 9.0.0. This is technically a breaking change if you use the `shared_vpc` submodule from that same repo. See https://github.com/terraform-google-modules/terraform-google-project-factory/releases/tag/v9.0.0. 

Proposed to be v0.1.2.